### PR TITLE
Clean up setting language and provide some more helpful information

### DIFF
--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -82,7 +82,7 @@ class WC_Google_Analytics extends WC_Integration {
 				'default' 			=> get_option( 'woocommerce_ga_support_display_advertising' ) ? get_option( 'woocommerce_ga_support_display_advertising' ) : 'no'  // Backwards compat
 			),
 			'ga_use_universal_analytics' => array(
-				'label' 			=> __( 'Use Universal Analytics instead of Classic Google Analytics.', 'woocommerce-google-analytics-integration' ),
+				'label' 			=> __( 'Use Universal Analytics instead of Classic Google Analytics. If you have not previously used Google Analytics for this site, check this box. Otherwise, <a href="https://developers.google.com/analytics/devguides/collection/upgrade/guide">follow step 1 of the Universal Analytics upgrade guide.</a> Enabling this setting will take care of step 2. <a href="https://support.google.com/analytics/answer/2790010?hl=en">Read more about Universal Analytics</a>.', 'woocommerce-google-analytics-integration' ),
 				'type' 				=> 'checkbox',
 				'checkboxgroup'		=> '',
 				'default' 			=> get_option( 'woocommerce_ga_use_universal_analytics' ) ? get_option( 'woocommerce_ga_use_universal_analytics' ) : 'no'  // Backwards compat

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -23,11 +23,11 @@ class WC_Google_Analytics extends WC_Integration {
 		$this->method_title       = __( 'Google Analytics', 'woocommerce-google-analytics-integration' );
 		$this->method_description = __( 'Google Analytics is a free service offered by Google that generates detailed statistics about the visitors to a website.', 'woocommerce-google-analytics-integration' );
 
-		// Load the settings.
+		// Load the settings
 		$this->init_form_fields();
 		$this->init_settings();
 
-		// Define user set variables
+		// Provide quick access to all of the integration settings
 		$this->ga_id                          = $this->get_option( 'ga_id' );
 		$this->ga_set_domain_name             = $this->get_option( 'ga_set_domain_name' );
 		$this->ga_standard_tracking_enabled   = $this->get_option( 'ga_standard_tracking_enabled' );
@@ -52,16 +52,13 @@ class WC_Google_Analytics extends WC_Integration {
 	}
 
 	/**
-	 * Initialise Settings Form Fields
-	 *
-	 * @return void
+	 * Tells WooCommerce which settings to display under the "integration" tab
 	 */
 	public function init_form_fields() {
-
 		$this->form_fields = array(
 			'ga_id' => array(
 				'title' 			=> __( 'Google Analytics ID', 'woocommerce-google-analytics-integration' ),
-				'description' 		=> __( 'Log into your google analytics account to find your ID. e.g. <code>UA-XXXXX-X</code>', 'woocommerce-google-analytics-integration' ),
+				'description' 		=> __( 'Log into your Google Analytics account to find your ID. e.g. <code>UA-XXXXX-X</code>', 'woocommerce-google-analytics-integration' ),
 				'type' 				=> 'text',
 				'default' 			=> get_option( 'woocommerce_ga_id' ) // Backwards compat
 			),
@@ -72,8 +69,8 @@ class WC_Google_Analytics extends WC_Integration {
 				'default' 			=> ''
 			),
 			'ga_standard_tracking_enabled' => array(
-				'title' 			=> __( 'Tracking code', 'woocommerce-google-analytics-integration' ),
-				'label' 			=> __( 'Add tracking code to your site. You don\'t need to enable this if using a 3rd party analytics plugin.', 'woocommerce-google-analytics-integration' ),
+				'title' 			=> __( 'Options', 'woocommerce-google-analytics-integration' ),
+				'label' 			=> __( 'Enable standard Google Analytics tracking. Adds standard analytics tracking code to your site. This tracks session data such as demographics, system, etc. You don\'t need to enable this if you are using a 3rd party analytics plugin.', 'woocommerce-google-analytics-integration' ),
 				'type' 				=> 'checkbox',
 				'checkboxgroup'		=> 'start',
 				'default' 			=> get_option( 'woocommerce_ga_standard_tracking_enabled' ) ? get_option( 'woocommerce_ga_standard_tracking_enabled' ) : 'no'  // Backwards compat
@@ -85,7 +82,7 @@ class WC_Google_Analytics extends WC_Integration {
 				'default' 			=> get_option( 'woocommerce_ga_support_display_advertising' ) ? get_option( 'woocommerce_ga_support_display_advertising' ) : 'no'  // Backwards compat
 			),
 			'ga_use_universal_analytics' => array(
-				'label' 			=> __( 'Use Universal Analytics instead of Classic Google Analytics', 'woocommerce-google-analytics-integration' ),
+				'label' 			=> __( 'Use Universal Analytics instead of Classic Google Analytics.', 'woocommerce-google-analytics-integration' ),
 				'type' 				=> 'checkbox',
 				'checkboxgroup'		=> '',
 				'default' 			=> get_option( 'woocommerce_ga_use_universal_analytics' ) ? get_option( 'woocommerce_ga_use_universal_analytics' ) : 'no'  // Backwards compat
@@ -97,13 +94,14 @@ class WC_Google_Analytics extends WC_Integration {
 				'default' 			=> 'no'
 			),
 			'ga_ecommerce_tracking_enabled' => array(
-				'label' 			=> __( 'Add eCommerce tracking code to the thankyou page', 'woocommerce-google-analytics-integration' ),
+				'title'             => __( 'Data to track', 'woocommerce-google-analytics-integration' ),
+				'label' 			=> __( 'Transactions (requires a payment gateway that redirects to the thank you/order received page).', 'woocommerce-google-analytics-integration' ),
 				'type' 				=> 'checkbox',
 				'checkboxgroup'		=> '',
 				'default' 			=> get_option( 'woocommerce_ga_ecommerce_tracking_enabled' ) ? get_option( 'woocommerce_ga_ecommerce_tracking_enabled' ) : 'no'  // Backwards compat
 			),
 			'ga_event_tracking_enabled' => array(
-				'label' 			=> __( 'Add event tracking code for add to cart actions', 'woocommerce-google-analytics-integration' ),
+				'label' 			=> __( 'Add to Cart Actions.', 'woocommerce-google-analytics-integration' ),
 				'type' 				=> 'checkbox',
 				'checkboxgroup'		=> 'end',
 				'default' 			=> 'no'

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -70,7 +70,7 @@ class WC_Google_Analytics extends WC_Integration {
 			),
 			'ga_standard_tracking_enabled' => array(
 				'title' 			=> __( 'Options', 'woocommerce-google-analytics-integration' ),
-				'label' 			=> __( 'Enable standard Google Analytics tracking. Adds standard analytics tracking code to your site. This tracks session data such as demographics, system, etc. You don\'t need to enable this if you are using a 3rd party analytics plugin.', 'woocommerce-google-analytics-integration' ),
+				'label' 			=> __( 'Enable standard Google Analytics tracking. This tracks session data such as demographics, system, etc. You don\'t need to enable this if you are using a 3rd party analytics plugin.', 'woocommerce-google-analytics-integration' ),
 				'type' 				=> 'checkbox',
 				'checkboxgroup'		=> 'start',
 				'default' 			=> get_option( 'woocommerce_ga_standard_tracking_enabled' ) ? get_option( 'woocommerce_ga_standard_tracking_enabled' ) : 'no'  // Backwards compat


### PR DESCRIPTION
As part of cleaning up the Analytics plugin, I wanted to fix up some of the settings language to make it clear when and why to enable something. I also wanted to separate out the "what to track" options from the other settings since we will be adding more as part of enhanced eCommerce (#17).

I also added a few notes around requirements. Mainly that tracking transactions requires a gateway that redirects to order received (all default gateways), and how to upgrade to universal analytics.