### PR TITLE
Display a helpful banner after installing the analytics plugin

### DIFF
--- a/includes/class-wc-google-analytics-info-banner.php
+++ b/includes/class-wc-google-analytics-info-banner.php
@@ -29,7 +29,7 @@ class WC_Google_Analytics_Info_Banner {
 	public function __construct( $dismissed = false, $ga_id = '' ) {
 		$this->is_dismissed = (bool) $dismissed;
 		if ( ! empty( $ga_id ) ) {
-			//$this->is_dismissed = true;
+			$this->is_dismissed = true;
 		}
 
 		// Don't bother setting anything else up if we are not going to show the notice

--- a/includes/class-wc-google-analytics-info-banner.php
+++ b/includes/class-wc-google-analytics-info-banner.php
@@ -60,6 +60,7 @@ class WC_Google_Analytics_Info_Banner {
 			$configure,
 			__( 'After configuring the plugin, please give Google Analytics 24 hours to start displaying results.', 'woocommerce-google-analytics-integration' ),
 			__( 'For transaction tracking to properly work, you will need to use a payment gateway that redirects the customer back to a WooCommerce order received/thank you page.', 'woocommerce-google-analytics-integration' ),
+			__( 'You must enable Ecommerce reporting in Google Analytics. <a href="https://support.google.com/analytics/answer/1009612?hl=en#Enable">See here for more information</a>.')
 		);
 
 		// Display the message..

--- a/includes/class-wc-google-analytics-info-banner.php
+++ b/includes/class-wc-google-analytics-info-banner.php
@@ -1,0 +1,116 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC_Google_Analytics_Info_Banner class
+ *
+ * Displays a message after install (if not dismissed and GA is not already configured) about how to configure the analytics plugin
+ */
+class WC_Google_Analytics_Info_Banner {
+
+	/** @var object Class Instance */
+	private static $instance;
+
+	/** @var boolean If the banner has been dismissed */
+	private $is_dismissed = false;
+
+	/**
+	 * Get the class instance
+	 */
+	public static function get_instance( $dismissed = false, $ga_id = '' ) {
+		return null === self::$instance ? ( self::$instance = new self( $dismissed, $ga_id ) ) : self::$instance;
+	}
+
+	/**
+	 * Constructor
+	 */
+	public function __construct( $dismissed = false, $ga_id = '' ) {
+		$this->is_dismissed = (bool) $dismissed;
+		if ( ! empty( $ga_id ) ) {
+			//$this->is_dismissed = true;
+		}
+
+		// Don't bother setting anything else up if we are not going to show the notice
+		if ( true === $this->is_dismissed ) {
+			return;
+		}
+
+		add_action( 'admin_notices', array( $this, 'banner' ) );
+		add_action( 'admin_init', array( $this, 'dismiss_banner' ) );
+	}
+
+	/**
+	 * Displays a info banner on WooCommerce settings pages
+	 */
+	public function banner() {
+		$screen = get_current_screen();
+
+		if ( ! in_array( $screen->base, array( 'woocommerce_page_wc-settings' ) ) || $screen->is_network || $screen->action ) {
+			return;
+		}
+
+		$integration_url = esc_url( admin_url('admin.php?page=wc-settings&tab=integration' ) );
+		$dismiss_url = $this->dismiss_url();
+
+		$heading = __( 'Google Analytics &amp; WooCommerce', 'woocommerce-google-analytics-integration' );
+		$configure = sprintf( __( 'Make sure to configure this plugin under the WooCommerce <a href="%s">integration tab</a>.' ), $integration_url );
+		$messages = array(
+			$configure,
+			__( 'After configuring the plugin, please give Google Analytics 24 hours to start displaying results.', 'woocommerce-google-analytics-integration' ),
+			__( 'For transaction tracking to properly work, you will need to use a payment gateway that redirects the customer back to a WooCommerce order received/thank you page.', 'woocommerce-google-analytics-integration' ),
+		);
+
+		// Display the message..
+		echo '<div class="updated fade"><p><strong>' . $heading . '</strong> ';
+		echo '<a href="' . esc_url( $dismiss_url ). '" title="' . __( 'Dismiss this notice.', 'woocommerce-google-analytics-integration' ) . '"> ' . __( '(Dismiss)', 'woocommerce-google-analytics-integration' ) . '</a>';
+		echo '<ul>';
+		foreach ( $messages as $message ) {
+			echo '<li>' . $message . '</li>';
+		}
+		echo "</ul></p></div>\n";
+	}
+
+	/**
+	 * Returns the url that the user clicks to remove the info banner
+	 * @return (string)
+	 */
+	function dismiss_url() {
+		$url = admin_url( 'admin.php' );
+
+		$url = add_query_arg( array(
+			'page'      => 'wc-settings',
+			'tab'       => 'integration',
+			'wc-notice' => 'dismiss-info-banner',
+		), $url );
+
+		return wp_nonce_url( $url, 'woocommerce_info_banner_dismiss' );
+	}
+
+	/**
+	 * Handles the dismiss action so that the banner can be permanently hidden
+	 */
+	function dismiss_banner() {
+		if ( ! isset( $_GET['wc-notice'] ) ) {
+			return;
+		}
+
+		if ( 'dismiss-info-banner' !== $_GET['wc-notice'] ) {
+			return;
+		}
+
+		if ( ! check_admin_referer( 'woocommerce_info_banner_dismiss' ) ) {
+			return;
+		}
+
+		update_option( 'woocommerce_dismissed_info_banner', true );
+
+		if ( wp_get_referer() ) {
+			wp_safe_redirect( wp_get_referer() );
+		} else {
+			wp_safe_redirect( admin_url( 'admin.php?page=wc-settings&tab=integration' ) );
+		}
+	}
+
+}

--- a/includes/class-wc-google-analytics-info-banner.php
+++ b/includes/class-wc-google-analytics-info-banner.php
@@ -47,7 +47,7 @@ class WC_Google_Analytics_Info_Banner {
 	public function banner() {
 		$screen = get_current_screen();
 
-		if ( ! in_array( $screen->base, array( 'woocommerce_page_wc-settings' ) ) || $screen->is_network || $screen->action ) {
+		if ( ! in_array( $screen->base, array( 'woocommerce_page_wc-settings', 'plugins' ) ) || $screen->is_network || $screen->action ) {
 			return;
 		}
 
@@ -55,22 +55,12 @@ class WC_Google_Analytics_Info_Banner {
 		$dismiss_url = $this->dismiss_url();
 
 		$heading = __( 'Google Analytics &amp; WooCommerce', 'woocommerce-google-analytics-integration' );
-		$configure = sprintf( __( 'Make sure to configure this plugin under the WooCommerce <a href="%s">integration tab</a>.' ), $integration_url );
-		$messages = array(
-			$configure,
-			__( 'After configuring the plugin, please give Google Analytics 24 hours to start displaying results.', 'woocommerce-google-analytics-integration' ),
-			__( 'For transaction tracking to properly work, you will need to use a payment gateway that redirects the customer back to a WooCommerce order received/thank you page.', 'woocommerce-google-analytics-integration' ),
-			__( 'You must enable Ecommerce reporting in Google Analytics. <a href="https://support.google.com/analytics/answer/1009612?hl=en#Enable">See here for more information</a>.')
-		);
+		$configure = sprintf( __( '<a href="%s">Connect WooCommerce to Google Analytics</a> to finish setting up this integration.' ), $integration_url );
 
 		// Display the message..
 		echo '<div class="updated fade"><p><strong>' . $heading . '</strong> ';
 		echo '<a href="' . esc_url( $dismiss_url ). '" title="' . __( 'Dismiss this notice.', 'woocommerce-google-analytics-integration' ) . '"> ' . __( '(Dismiss)', 'woocommerce-google-analytics-integration' ) . '</a>';
-		echo '<ul>';
-		foreach ( $messages as $message ) {
-			echo '<li>' . $message . '</li>';
-		}
-		echo "</ul></p></div>\n";
+		echo '<p>' . $configure . "</p></div>\n";
 	}
 
 	/**

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -36,6 +36,14 @@ class WC_Google_Analytics extends WC_Integration {
 		$this->ga_anonymize_enabled           = $this->get_option( 'ga_anonymize_enabled' );
 		$this->ga_ecommerce_tracking_enabled  = $this->get_option( 'ga_ecommerce_tracking_enabled' );
 		$this->ga_event_tracking_enabled      = $this->get_option( 'ga_event_tracking_enabled' );
+		$this->dismissed_info_banner          = get_option( 'woocommerce_dismissed_info_banner' );
+
+
+		// Display an info banner on how to configure WooCommerce
+		if ( is_admin() ) {
+			include_once( 'class-wc-google-analytics-info-banner.php' );
+			WC_Google_Analytics_Info_Banner::get_instance( $this->dismissed_info_banner, $this->ga_id );
+		}
 
 		// Actions
 		add_action( 'woocommerce_update_options_integration_google_analytics', array( $this, 'process_admin_options') );

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -121,7 +121,7 @@ class WC_Google_Analytics extends WC_Integration {
 	}
 
 	/**
-	 * 
+	 * Shows some additional help text after saving the Google Analytics settings
 	 */
 	function show_options_info() {
 		$this->method_description .= "<br /><strong>" . __( 'Please give Google Analytics 24 hours to start displaying results.', 'woocommerce-google-analytics-integration' ) . "</strong>";

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -47,6 +47,7 @@ class WC_Google_Analytics extends WC_Integration {
 
 		// Actions
 		add_action( 'woocommerce_update_options_integration_google_analytics', array( $this, 'process_admin_options') );
+		add_action( 'woocommerce_update_options_integration_google_analytics', array( $this, 'show_options_info') );
 
 		// Tracking code
 		add_action( 'wp_head', array( $this, 'tracking_code_display' ), 999999 );
@@ -117,6 +118,16 @@ class WC_Google_Analytics extends WC_Integration {
 				'default' 			=> 'no'
 			)
 		);
+	}
+
+	/**
+	 * 
+	 */
+	function show_options_info() {
+		$this->method_description .= "<br /><strong>" . __( 'Please give Google Analytics 24 hours to start displaying results.', 'woocommerce-google-analytics-integration' ) . "</strong>";
+		if ( isset( $_REQUEST['woocommerce_google_analytics_ga_ecommerce_tracking_enabled'] ) && true === (bool) $_REQUEST['woocommerce_google_analytics_ga_ecommerce_tracking_enabled'] ) {
+			$this->method_description .= "<br /><strong>" . __( 'For transaction tracking to work properly, you will need to use a payment gateway that redirects the customer back to a WooCommerce order received/thank you page.', 'woocommerce-google-analytics-integration' ) . "</strong>";
+		}
 	}
 
 	/**


### PR DESCRIPTION
I mentioned this idea to @claudiosmweb the other day, but displaying some additional information (that may have been missed in the readme) would help users understand some of the requirements of the plugin and might reduce some of the initial "it's broken"/"my analytics are not showing" support requests. Think of it as a super simple onboarding message :).

The notice can be permanently dismissed by the user, only displays on WooCommerce settings pages, and will also disappear when the GA ID is set (so it should not show for upgraded users unless they have never configured GA before).

Here is what it looks like:
![preview of info banner](https://cldup.com/PhALukcPOG-2000x2000.png) 