### PR TITLE
Add Enhanced Ecommerce Capabilities

### DIFF
--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -440,6 +440,27 @@ class WC_Google_Analytics_JS {
 	}
 
 	/**
+	 * Tracks when the checkout process is started
+	 */
+	function checkout_process( $cart ) {
+		$code = "";
+
+		foreach ( $cart as $cart_item_key => $cart_item ) {
+			$product     = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
+			$code .= "ga( 'ec:addProduct', {
+				'id': '" . esc_js( $product->get_sku() ? $product->get_sku() : $product->id ) . "',
+				'name': '" . esc_js( $product->get_title() ) . "',
+				'category': " . self::product_get_category_line( $product ) . "
+				'price': '" . esc_js( $product->get_price() ) . "',
+				'quantity': '" . esc_js( $cart_item['quantity'] ) . "'
+			} );";
+		}
+
+		$code .= "ga( 'ec:setAction','checkout' );";
+		wc_enqueue_js( $code );
+	}
+
+	/**
 	 * Add to cart
 	 *
 	 * @param array $parameters associative array of _trackEvent parameters

--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -425,6 +425,21 @@ class WC_Google_Analytics_JS {
 	}
 
 	/**
+	 * Tracks a product detail view
+	 */
+	function product_detail( $product ) {
+		wc_enqueue_js( "
+			ga( 'ec:addProduct', {
+				'id': '" . esc_js( $product->get_sku() ? $product->get_sku() : $product->id ) . "',
+				'name': '" . esc_js( $product->get_title() ) . "',
+				'category': " . self::product_get_category_line( $product ) . "
+				'price': '" . esc_js( $product->get_price() ) . "',
+			} );
+
+			ga( 'ec:setAction', 'detail' );" );
+	}
+
+	/**
 	 * Add to cart
 	 *
 	 * @param array $parameters associative array of _trackEvent parameters

--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -110,7 +110,7 @@ class WC_Google_Analytics_JS {
 	/**
 	 * Builds the addImpression object
 	 */
-	public static function cart_search_impression( $product, $position ) {
+	public static function listing_impression( $product, $position ) {
 		if ( isset( $_GET['s'] ) ) {
 			$list = "Search Results";
 		} else {
@@ -125,6 +125,39 @@ class WC_Google_Analytics_JS {
 				'list': '" . esc_js( $list ) . "',
 				'position': " . esc_js( $position ) . "
 			} );
+		" );
+	}
+
+	/**
+	 * Builds an addProduct and click object
+	 */
+	public static function listing_click( $product, $position ) {
+		if ( isset( $_GET['s'] ) ) {
+			$list = "Search Results";
+		} else {
+			$list = "Product List";
+		}
+
+		echo( "
+			<script>
+			(function($) {
+				$( '.products .post-" . esc_js( $product->id ) . " a' ).click( function() {
+					if ( true === $(this).hasClass( 'add_to_cart_button' ) ) {
+						return;
+					}
+
+					ga( 'ec:addProduct', {
+						'id': '" . esc_js( $product->id ) . "',
+						'name': '" . esc_js( $product->get_title() ) . "',
+						'category': " . self::product_get_category_line( $product ) . "
+						'position': " . esc_js( $position ) . "
+					});
+
+					ga( 'ec:setAction', 'click', { list: '" . esc_js( $list ) . "' });
+					ga( 'send', 'event', 'UX', 'click', ' " . esc_js( $list ) . "' );
+				});
+			})(jQuery);
+			</script>
 		" );
 	}
 

--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -147,7 +147,7 @@ class WC_Google_Analytics_JS {
 			$anonymize_enabled = "ga( 'set', 'anonymizeIp', true );";
 		}
 
-		return "(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+		$code = "(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 		})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
@@ -156,8 +156,15 @@ class WC_Google_Analytics_JS {
 		$support_display_advertising .
 		$anonymize_enabled . "
 		ga( 'set', 'dimension1', '" . $logged_in . "' );
-		ga( 'send', 'pageview' );
-		ga('require', 'ecommerce', 'ecommerce.js');";
+		ga( 'send', 'pageview' );\n";
+
+		if ( 'yes' === self::get( 'ga_enhanced_ecommerce_tracking_enabled' ) ) {
+			$code .= "ga( 'require', 'ec' );";
+		} else {
+			$code .= "ga( 'require', 'ecommerce', 'ecommerce.js');";
+		}
+
+		return $code;
 	}
 
 	/**

--- a/includes/class-wc-google-analytics-js.php
+++ b/includes/class-wc-google-analytics-js.php
@@ -344,6 +344,26 @@ class WC_Google_Analytics_JS {
 	}
 
 	/**
+	 * Tracks an enhanced ecommerce remove from cart action
+	 */
+	function remove_from_cart() {
+		echo( "
+			<script>
+			(function($) {
+				$( '.remove' ).click( function() {
+					ga( 'ec:addProduct', {
+						'id': ($(this).data('product_sku')) ? ('SKU: ' + $(this).data('product_sku')) : ('#' + $(this).data('product_id')),
+						'quantity': $(this).parent().parent().find( '.qty' ).val() ? $(this).parent().parent().find( '.qty' ).val() : '1',
+					} );
+					ga( 'ec:setAction', 'remove' );
+					ga( 'send', 'event', 'UX', 'click', 'remove from cart' );
+				});
+			})(jQuery);
+			</script>
+		" );
+	}
+
+	/**
 	 * Add to cart
 	 *
 	 * @param array $parameters associative array of _trackEvent parameters

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -52,6 +52,7 @@ class WC_Google_Analytics extends WC_Integration {
 		add_action( 'woocommerce_after_cart', array( $this, 'remove_from_cart' ) );
 		add_action( 'woocommerce_after_mini_cart', array( $this, 'remove_from_cart' ) );
 		add_filter( 'woocommerce_cart_item_remove_link', array( $this, 'remove_from_cart_attributes' ), 10, 2 );
+		add_filter( 'woocommerce_after_shop_loop_item', array( $this, 'cart_search_impression' ) );
 
 		// utm_nooverride parameter for Google AdWords
 		add_filter( 'woocommerce_get_return_url', array( $this, 'utm_nooverride' ) );
@@ -75,6 +76,7 @@ class WC_Google_Analytics extends WC_Integration {
 			'ga_enhanced_product_impression_enabled',
 			'ga_enhanced_checkout_process_enabled',
 			'ga_enhanced_refunds_enabled',
+			'ga_enhanced_product_detail_view_enabled',
 			'ga_event_tracking_enabled'
 		);
 
@@ -166,7 +168,15 @@ class WC_Google_Analytics extends WC_Integration {
 			),
 
 			'ga_enhanced_product_impression_enabled' => array(
-				'label' 			=> __( 'Product Impressions', 'woocommerce-google-analytics-integration' ),
+				'label' 			=> __( 'Product Impressions from Search Results', 'woocommerce-google-analytics-integration' ),
+				'description'       => __( 'Requires Enhanced eCommerce.', 'woocommerce-google-analytics-integration' ),
+				'type' 				=> 'checkbox',
+				'checkboxgroup'		=> '',
+				'default' 			=> 'yes'
+			),
+
+			'ga_enhanced_product_detail_view_enabled' => array(
+				'label' 			=> __( 'Product Detail Views', 'woocommerce-google-analytics-integration' ),
 				'description'       => __( 'Requires Enhanced eCommerce.', 'woocommerce-google-analytics-integration' ),
 				'type' 				=> 'checkbox',
 				'checkboxgroup'		=> '',
@@ -364,6 +374,26 @@ class WC_Google_Analytics extends WC_Integration {
 		}
 
 		WC_Google_Analytics_JS::get_instance()->event_tracking_code( $parameters, '.add_to_cart_button:not(.product_type_variable, .product_type_grouped)' );
+	}
+
+	/**
+	 * Measures a cart impression (from search results)
+	 */
+	public function cart_search_impression() {
+		if ( $this->disable_tracking( $this->ga_use_universal_analytics ) ) {
+			return;
+		}
+
+		if ( $this->disable_tracking( $this->ga_enhanced_ecommerce_tracking_enabled ) ) {
+			return;
+		}
+
+		if ( $this->disable_tracking( $this->ga_enhanced_product_impression_enabled ) ) {
+			return;
+		}
+
+		global $product, $woocommerce_loop;
+		WC_Google_Analytics_JS::get_instance()->cart_search_impression( $product, $woocommerce_loop['loop'] );
 	}
 
 	/**

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -52,8 +52,9 @@ class WC_Google_Analytics extends WC_Integration {
 		add_action( 'woocommerce_after_cart', array( $this, 'remove_from_cart' ) );
 		add_action( 'woocommerce_after_mini_cart', array( $this, 'remove_from_cart' ) );
 		add_filter( 'woocommerce_cart_item_remove_link', array( $this, 'remove_from_cart_attributes' ), 10, 2 );
-		add_filter( 'woocommerce_after_shop_loop_item', array( $this, 'listing_impression' ) );
-		add_filter( 'woocommerce_after_shop_loop_item', array( $this, 'listing_click' ) );
+		add_action( 'woocommerce_after_shop_loop_item', array( $this, 'listing_impression' ) );
+		add_action( 'woocommerce_after_shop_loop_item', array( $this, 'listing_click' ) );
+		add_action( 'woocommerce_after_single_product', array( $this, 'product_detail' ) );
 
 		// utm_nooverride parameter for Google AdWords
 		add_filter( 'woocommerce_get_return_url', array( $this, 'utm_nooverride' ) );
@@ -424,6 +425,26 @@ class WC_Google_Analytics extends WC_Integration {
 
 		global $product, $woocommerce_loop;
 		WC_Google_Analytics_JS::get_instance()->listing_click( $product, $woocommerce_loop['loop'] );
+	}
+
+	/**
+	 * Measure a product detail view
+	 */
+	public function product_detail() {
+		if ( $this->disable_tracking( $this->ga_use_universal_analytics ) ) {
+			return;
+		}
+
+		if ( $this->disable_tracking( $this->ga_enhanced_ecommerce_tracking_enabled ) ) {
+			return;
+		}
+
+		if ( $this->disable_tracking( $this->ga_enhanced_product_detail_view_enabled ) ) {
+			return;
+		}
+
+		global $product;
+		WC_Google_Analytics_JS::get_instance()->product_detail( $product );
 	}
 
 	/**

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -52,7 +52,8 @@ class WC_Google_Analytics extends WC_Integration {
 		add_action( 'woocommerce_after_cart', array( $this, 'remove_from_cart' ) );
 		add_action( 'woocommerce_after_mini_cart', array( $this, 'remove_from_cart' ) );
 		add_filter( 'woocommerce_cart_item_remove_link', array( $this, 'remove_from_cart_attributes' ), 10, 2 );
-		add_filter( 'woocommerce_after_shop_loop_item', array( $this, 'cart_search_impression' ) );
+		add_filter( 'woocommerce_after_shop_loop_item', array( $this, 'listing_impression' ) );
+		add_filter( 'woocommerce_after_shop_loop_item', array( $this, 'listing_click' ) );
 
 		// utm_nooverride parameter for Google AdWords
 		add_filter( 'woocommerce_get_return_url', array( $this, 'utm_nooverride' ) );
@@ -74,6 +75,7 @@ class WC_Google_Analytics extends WC_Integration {
 			'ga_enhanced_ecommerce_tracking_enabled',
 			'ga_enhanced_remove_from_cart_enabled',
 			'ga_enhanced_product_impression_enabled',
+			'ga_enhanced_product_click_enabled',
 			'ga_enhanced_checkout_process_enabled',
 			'ga_enhanced_refunds_enabled',
 			'ga_enhanced_product_detail_view_enabled',
@@ -168,7 +170,15 @@ class WC_Google_Analytics extends WC_Integration {
 			),
 
 			'ga_enhanced_product_impression_enabled' => array(
-				'label' 			=> __( 'Product Impressions from Search Results', 'woocommerce-google-analytics-integration' ),
+				'label' 			=> __( 'Product Impressions from Listing Pages', 'woocommerce-google-analytics-integration' ),
+				'description'       => __( 'Requires Enhanced eCommerce.', 'woocommerce-google-analytics-integration' ),
+				'type' 				=> 'checkbox',
+				'checkboxgroup'		=> '',
+				'default' 			=> 'yes'
+			),
+
+			'ga_enhanced_product_click_enabled' => array(
+				'label' 			=> __( 'Product Clicks from Listing Pages', 'woocommerce-google-analytics-integration' ),
 				'description'       => __( 'Requires Enhanced eCommerce.', 'woocommerce-google-analytics-integration' ),
 				'type' 				=> 'checkbox',
 				'checkboxgroup'		=> '',
@@ -377,9 +387,9 @@ class WC_Google_Analytics extends WC_Integration {
 	}
 
 	/**
-	 * Measures a cart impression (from search results)
+	 * Measures a listing impression (from search results)
 	 */
-	public function cart_search_impression() {
+	public function listing_impression() {
 		if ( $this->disable_tracking( $this->ga_use_universal_analytics ) ) {
 			return;
 		}
@@ -393,7 +403,27 @@ class WC_Google_Analytics extends WC_Integration {
 		}
 
 		global $product, $woocommerce_loop;
-		WC_Google_Analytics_JS::get_instance()->cart_search_impression( $product, $woocommerce_loop['loop'] );
+		WC_Google_Analytics_JS::get_instance()->listing_impression( $product, $woocommerce_loop['loop'] );
+	}
+
+	/**
+	 * Measure a product click from a listing page
+	 */
+	public function listing_click() {
+		if ( $this->disable_tracking( $this->ga_use_universal_analytics ) ) {
+			return;
+		}
+
+		if ( $this->disable_tracking( $this->ga_enhanced_ecommerce_tracking_enabled ) ) {
+			return;
+		}
+
+		if ( $this->disable_tracking( $this->ga_enhanced_product_click_enabled ) ) {
+			return;
+		}
+
+		global $product, $woocommerce_loop;
+		WC_Google_Analytics_JS::get_instance()->listing_click( $product, $woocommerce_loop['loop'] );
 	}
 
 	/**

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -292,6 +292,14 @@ class WC_Google_Analytics extends WC_Integration {
 		$parameters['action']   = "'" . __( 'Add to Cart', 'woocommerce-google-analytics-integration' ) . "'";
 		$parameters['label']    = "'" . esc_js( $product->get_sku() ? __( 'SKU:', 'woocommerce-google-analytics-integration' ) . ' ' . $product->get_sku() : "#" . $product->id ) . "'";
 
+		if ( ! $this->disable_tracking( $this->ga_enhanced_ecommerce_tracking_enabled ) ) {
+			$code = "ga( 'ec:addProduct', {";
+			$code .= "'id': '" . esc_js( $product->get_sku() ? $product->get_sku() : $product->id ) . "',";
+			$code .= "'quantity': $( 'input.qty' ).val() ? $( 'input.qty' ).val() : '1'";
+			$code .= "} );";
+			$parameters['enhanced'] = $code;
+		}
+
 		WC_Google_Analytics_JS::get_instance()->event_tracking_code( $parameters, '.single_add_to_cart_button' );
 	}
 
@@ -311,6 +319,14 @@ class WC_Google_Analytics extends WC_Integration {
 		$parameters['category'] = "'" . __( 'Products', 'woocommerce-google-analytics-integration' ) . "'";
 		$parameters['action']   = "'" . __( 'Add to Cart', 'woocommerce-google-analytics-integration' ) . "'";
 		$parameters['label']    = "($(this).data('product_sku')) ? ('SKU: ' + $(this).data('product_sku')) : ('#' + $(this).data('product_id'))"; // Product SKU or ID
+
+		if ( ! $this->disable_tracking( $this->ga_enhanced_ecommerce_tracking_enabled ) ) {
+			$code = "ga( 'ec:addProduct', {";
+			$code .= "'id': ($(this).data('product_sku')) ? ('SKU: ' + $(this).data('product_sku')) : ('#' + $(this).data('product_id')),";
+			$code .= "'quantity': $(this).data('quantity')";
+			$code .= "} );";
+			$parameters['enhanced'] = $code;
+		}
 
 		WC_Google_Analytics_JS::get_instance()->event_tracking_code( $parameters, '.add_to_cart_button:not(.product_type_variable, .product_type_grouped)' );
 	}

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -55,6 +55,7 @@ class WC_Google_Analytics extends WC_Integration {
 		add_action( 'woocommerce_after_shop_loop_item', array( $this, 'listing_impression' ) );
 		add_action( 'woocommerce_after_shop_loop_item', array( $this, 'listing_click' ) );
 		add_action( 'woocommerce_after_single_product', array( $this, 'product_detail' ) );
+		add_action( 'woocommerce_after_checkout_form', array( $this, 'checkout_process' ) );
 
 		// utm_nooverride parameter for Google AdWords
 		add_filter( 'woocommerce_get_return_url', array( $this, 'utm_nooverride' ) );
@@ -445,6 +446,25 @@ class WC_Google_Analytics extends WC_Integration {
 
 		global $product;
 		WC_Google_Analytics_JS::get_instance()->product_detail( $product );
+	}
+
+	/**
+	 * Tracks when the checkout form is loaded
+	 */
+	public function checkout_process( $checkout ) {
+		if ( $this->disable_tracking( $this->ga_use_universal_analytics ) ) {
+			return;
+		}
+
+		if ( $this->disable_tracking( $this->ga_enhanced_ecommerce_tracking_enabled ) ) {
+			return;
+		}
+
+		if ( $this->disable_tracking( $this->ga_enhanced_checkout_process_enabled ) ) {
+			return;
+		}
+
+		WC_Google_Analytics_JS::get_instance()->checkout_process( WC()->cart->get_cart() );
 	}
 
 	/**

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -79,7 +79,6 @@ class WC_Google_Analytics extends WC_Integration {
 			'ga_enhanced_product_impression_enabled',
 			'ga_enhanced_product_click_enabled',
 			'ga_enhanced_checkout_process_enabled',
-			'ga_enhanced_refunds_enabled',
 			'ga_enhanced_product_detail_view_enabled',
 			'ga_event_tracking_enabled'
 		);
@@ -141,7 +140,7 @@ class WC_Google_Analytics extends WC_Integration {
 			),
 			'ga_enhanced_ecommerce_tracking_enabled' => array(
 				'label'         => __( 'Enable Enhanced eCommerce ', 'woocommerce-google-analytics-integration' ),
-				'description'   => sprintf( __( 'Enhanced eCommerce allows you to measure more user interactions with your store, including: product impressions, starting the checkout process, adding and removing cart items, and refunds. Universal Analytics must be enabled for Enhanced Analytics to work. Before enabling this setting, turn on Enhanced Ecommerce in your Google Analytics dashboard. <a href="%s">See here for more information</a>.', 'woocommerce-google-analytics-integration' ), 'https://support.google.com/analytics/answer/6032539?hl=en' ),
+				'description'   => sprintf( __( 'Enhanced eCommerce allows you to measure more user interactions with your store, including: product impressions, product detail views, starting the checkout process, adding cart items, and removing cart items. Universal Analytics must be enabled for Enhanced eCommerce to work. Before enabling this setting, turn on Enhanced Ecommerce in your Google Analytics dashboard. <a href="%s">See here for more information</a>.', 'woocommerce-google-analytics-integration' ), 'https://support.google.com/analytics/answer/6032539?hl=en' ),
 				'type'          => 'checkbox',
 				'checkboxgroup' => '',
 				'default'       => 'no'
@@ -200,14 +199,6 @@ class WC_Google_Analytics extends WC_Integration {
 				'description'       => __( 'Requires Enhanced eCommerce.', 'woocommerce-google-analytics-integration' ),
 				'type' 				=> 'checkbox',
 				'checkboxgroup'		=> '',
-				'default' 			=> 'yes'
-			),
-
-			'ga_enhanced_refunds_enabled' => array(
-				'label' 			=> __( 'Refund Transactions', 'woocommerce-google-analytics-integration' ),
-				'description'       => __( 'Requires Enhanced eCommerce.', 'woocommerce-google-analytics-integration' ),
-				'type' 				=> 'checkbox',
-				'checkboxgroup'		=> 'end',
 				'default' 			=> 'yes'
 			),
 		);

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -67,6 +67,11 @@ class WC_Google_Analytics extends WC_Integration {
 			'ga_use_universal_analytics',
 			'ga_anonymize_enabled',
 			'ga_ecommerce_tracking_enabled',
+			'ga_enhanced_ecommerce_tracking_enabled',
+			'ga_enhanced_remove_from_cart_enabled',
+			'ga_enhanced_product_impression_enabled',
+			'ga_enhanced_checkout_process_enabled',
+			'ga_enhanced_refunds_enabled',
 			'ga_event_tracking_enabled'
 		);
 
@@ -125,20 +130,61 @@ class WC_Google_Analytics extends WC_Integration {
 				'checkboxgroup' => '',
 				'default'       => 'yes'
 			),
+			'ga_enhanced_ecommerce_tracking_enabled' => array(
+				'label'         => __( 'Enable Enhanced eCommerce ', 'woocommerce-google-analytics-integration' ),
+				'description'   => sprintf( __( 'Enhanced eCommerce allows you to measure more user interactions with your store, including: product impressions, starting the checkout process, adding and removing cart items, and refunds. Universal Analytics must be enabled for Enhanced Analytics to work. Before enabling this setting, turn on Enhanced Ecommerce in your Google Analytics dashboard. <a href="%s">See here for more information</a>.', 'woocommerce-google-analytics-integration' ), 'https://support.google.com/analytics/answer/6032539?hl=en' ),
+				'type'          => 'checkbox',
+				'checkboxgroup' => '',
+				'default'       => 'no'
+			),
 			'ga_ecommerce_tracking_enabled' => array(
 				'title'             => __( 'Data to Track', 'woocommerce-google-analytics-integration' ),
-				'label' 			=> __( 'Transactions', 'woocommerce-google-analytics-integration' ),
+				'label' 			=> __( 'Purchase Transactions', 'woocommerce-google-analytics-integration' ),
 				'description' 			=> __( 'This requires a payment gateway that redirects to the thank you/order received page after payment. Orders paid with gateways which do not do this will not be tracked.', 'woocommerce-google-analytics-integration' ),
 				'type' 				=> 'checkbox',
-				'checkboxgroup'		=> '',
+				'checkboxgroup'		=> 'start',
 				'default' 			=> get_option( 'woocommerce_ga_ecommerce_tracking_enabled' ) ? get_option( 'woocommerce_ga_ecommerce_tracking_enabled' ) : 'yes'  // Backwards compat
 			),
 			'ga_event_tracking_enabled' => array(
 				'label' 			=> __( 'Add to Cart Events', 'woocommerce-google-analytics-integration' ),
 				'type' 				=> 'checkbox',
+				'checkboxgroup'		=> '',
+				'default' 			=> 'yes'
+			),
+
+			// Enhanced eCommerce Settings
+
+			'ga_enhanced_remove_from_cart_enabled' => array(
+				'label' 			=> __( 'Remove from Cart Events', 'woocommerce-google-analytics-integration' ),
+				'description'       => __( 'Requires Enhanced eCommerce.', 'woocommerce-google-analytics-integration' ),
+				'type' 				=> 'checkbox',
+				'checkboxgroup'		=> '',
+				'default' 			=> 'yes'
+			),
+
+			'ga_enhanced_product_impression_enabled' => array(
+				'label' 			=> __( 'Product Impressions', 'woocommerce-google-analytics-integration' ),
+				'description'       => __( 'Requires Enhanced eCommerce.', 'woocommerce-google-analytics-integration' ),
+				'type' 				=> 'checkbox',
+				'checkboxgroup'		=> '',
+				'default' 			=> 'yes'
+			),
+
+			'ga_enhanced_checkout_process_enabled' => array(
+				'label' 			=> __( 'Checkout Process Initiated', 'woocommerce-google-analytics-integration' ),
+				'description'       => __( 'Requires Enhanced eCommerce.', 'woocommerce-google-analytics-integration' ),
+				'type' 				=> 'checkbox',
+				'checkboxgroup'		=> '',
+				'default' 			=> 'yes'
+			),
+
+			'ga_enhanced_refunds_enabled' => array(
+				'label' 			=> __( 'Refund Transactions', 'woocommerce-google-analytics-integration' ),
+				'description'       => __( 'Requires Enhanced eCommerce.', 'woocommerce-google-analytics-integration' ),
+				'type' 				=> 'checkbox',
 				'checkboxgroup'		=> 'end',
 				'default' 			=> 'yes'
-			)
+			),
 		);
 	}
 

--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -236,6 +236,11 @@ class WC_Google_Analytics extends WC_Integration {
 			}
 		}
 
+		if ( is_woocommerce() || is_cart() || is_checkout() ) {
+			$display_ecommerce_tracking = true;
+			echo $this->get_standard_tracking_code();
+		}
+
 		if ( ! $display_ecommerce_tracking && 'yes' === $this->ga_standard_tracking_enabled ) {
 			echo $this->get_standard_tracking_code();
 		}


### PR DESCRIPTION
Closes #17.

This PR adds GA's enhanced ecommerce functionality to the plugin. By default, it is off and requires flipping a setting under the integration tab (you also have to configure something on the GA side). Once it is turned on, it tracks removing a product from a cart, product impressions, product clicks, product detail views, checkout, adding to a cart, and transactions giving a full view of the entire ecommerce flow. Each of these can also be flipped off depending on what you want to track.