### PR TITLE
Bump info to 1.4.0-beta-1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woothemes, claudiosanches
 Tags: woocommerce, google analytics
 Requires at least: 3.8
-Tested up to: 4.0
+Tested up to: 4.3
 Stable tag: 1.3.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -11,7 +11,7 @@ Provides integration between Google Analytics and WooCommerce.
 
 == Description ==
 
-This plugin provides the integration between Google Analytics and the WooCommerce plugin. You can link a referral to a purchase and add transaction information to your Google Analytics data. It also supports the new Universal Analytics, eCommerce and event tracking.
+This plugin provides the integration between Google Analytics and the WooCommerce plugin. You can link a referral to a purchase and add transaction information to your Google Analytics data. It also supports the new Universal Analytics, eCommerce, and enhanced eCommerce event tracking.
 
 Starting WooCommerce 2.1, this integration will no longer be part of WooCommerce and will only be available by using this plugin.
 
@@ -63,6 +63,11 @@ Exact wording depends on the national data privacy laws and should be adjusted.
 1. Google Analytics Integration Settings.
 
 == Changelog ==
+
+= 1.4.0 - X =
+* Feature - Support for enhanced eCommerce (tracking full store process from view to order)
+* Tweak - Setting up the plugin is now clearer with some helpful links and clearer language
+* Refactor - JavaScript generation functions have been moved to their own class
 
 = 1.3.0 - 12/11/2014 =
 

--- a/woocommerce-google-analytics-integration.php
+++ b/woocommerce-google-analytics-integration.php
@@ -5,7 +5,7 @@
  * Description: Allows Google Analytics tracking code to be inserted into WooCommerce store pages.
  * Author: WooThemes
  * Author URI: http://woothemes.com
- * Version: 1.3.0
+ * Version: 1.4.0-beta-1
  * License: GPLv2 or later
  * Text Domain: woocommerce-google-analytics-integration
  * Domain Path: languages/
@@ -27,7 +27,7 @@ class WC_Google_Analytics_Integration {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.3.0';
+	const VERSION = '1.4.0';
 
 	/**
 	 * Instance of this class.


### PR DESCRIPTION
Since 1.4 has a lot of changes and is a refactor, we want to run a beta. Bumping some info before tagging a release.