### PR TITLE
Make sure the tracking code is not loaded twice on the checkout page

### DIFF
--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -272,7 +272,7 @@ class WC_Google_Analytics extends WC_Integration {
 			}
 		}
 
-		if ( is_woocommerce() || is_cart() || is_checkout() ) {
+		if ( is_woocommerce() || is_cart() || ( is_checkout() && ! $display_ecommerce_tracking ) ) {
 			$display_ecommerce_tracking = true;
 			echo $this->get_standard_tracking_code();
 		}


### PR DESCRIPTION
The tracking code is being run twice on the checkout page - if the code is already loaded, then we shouldn't bother showing the checkout code again.