### PR TITLE
Fix a PHP Notice

### DIFF
--- a/includes/class-wc-google-analytics.php
+++ b/includes/class-wc-google-analytics.php
@@ -244,6 +244,10 @@ class WC_Google_Analytics extends WC_Integration {
 			return;
 		}
 
+		if ( empty( $_GET['tab'] ) ) {
+			return;
+		}
+
 		if ( 'integration' !== $_GET['tab'] ) {
 			return;
 		}


### PR DESCRIPTION
This PR fixes a minor PHP notice shown when loading a settings page without a 'tab' query arg.

PHP Notice:  Undefined index: tab in includes/class-wc-google-analytics.php

