### PR TITLE
Correctly link to the GA setup from the info banner

### DIFF
--- a/includes/class-wc-google-analytics-info-banner.php
+++ b/includes/class-wc-google-analytics-info-banner.php
@@ -51,7 +51,7 @@ class WC_Google_Analytics_Info_Banner {
 			return;
 		}
 
-		$integration_url = esc_url( admin_url('admin.php?page=wc-settings&tab=integration' ) );
+		$integration_url = esc_url( admin_url('admin.php?page=wc-settings&tab=integration&section=google_analytics' ) );
 		$dismiss_url = $this->dismiss_url();
 
 		$heading = __( 'Google Analytics &amp; WooCommerce', 'woocommerce-google-analytics-integration' );


### PR DESCRIPTION
The "Connect WooCommerce to Google Analytics" link just sends you to the main WooCommerce integration page. We should be sending them to the correct tab as well, just in case there are multiple integrations configured.

No changelog is needed since this bit is new in 1.4 and is unreleased.