### PR TITLE
v1.4.0 Readme changelog fix

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -64,7 +64,7 @@ Exact wording depends on the national data privacy laws and should be adjusted.
 
 == Changelog ==
 
-= 1.4.0 - 20-11-2015
+= 1.4.0 - 20-11-2015 =
 * Feature - Support for enhanced eCommerce (tracking full store process from view to order)
 * Tweak - Setting up the plugin is now clearer with some helpful links and clearer language
 * Tweak - New filter on the ga global variable
@@ -103,3 +103,8 @@ Exact wording depends on the national data privacy laws and should be adjusted.
 = 1.0 - 22/11/2013 =
 
 * Initial release
+
+
+== Upgrade Notice ==
+= 1.4.0 =
+Adds support for enhanced eCommerce (tracking full store process from view to order)


### PR DESCRIPTION
The formatting on https://wordpress.org/plugins/woocommerce-google-analytics-integration/changelog/ isn't quite correct.

Also adds an upgrade notice in order to encourage people to upgrade.